### PR TITLE
update go and errors wrapping

### DIFF
--- a/dh.go
+++ b/dh.go
@@ -4,9 +4,8 @@ import (
 	"bytes"
 	"encoding/asn1"
 	"encoding/pem"
+	"fmt"
 	"math/big"
-
-	"github.com/pkg/errors"
 )
 
 // DH contains a prime (P) and a generator (G) number representing the DH parameters
@@ -21,7 +20,7 @@ func Decode(pemData []byte) (*DH, error) {
 
 	out := &DH{}
 	if _, err := asn1.Unmarshal(blk.Bytes, out); err != nil {
-		return nil, errors.Wrap(err, "Could not unmarshal ASN1")
+		return nil, fmt.Errorf("could not unmarshal ASN1: %w", err)
 	}
 
 	return out, nil
@@ -31,7 +30,7 @@ func Decode(pemData []byte) (*DH, error) {
 func (d DH) ToPEM() ([]byte, error) {
 	data, err := asn1.Marshal(d)
 	if err != nil {
-		return nil, errors.Wrap(err, "Unable to marshal ASN1 data")
+		return nil, fmt.Errorf("unable to marshal ASN1 data: %w", err)
 	}
 
 	buf := new(bytes.Buffer)

--- a/generator.go
+++ b/generator.go
@@ -3,9 +3,8 @@ package dhparam
 import (
 	"context"
 	"crypto/rand"
+	"fmt"
 	"math/big"
-
-	"github.com/pkg/errors"
 )
 
 const pemHeader = "DH PARAMETERS"
@@ -35,12 +34,12 @@ const (
 // GeneratorCallback is a type of function to receive GeneratorResults while the prime number is determined
 type GeneratorCallback func(r GeneratorResult)
 
-func nullCallback(r GeneratorResult) {}
+func nullCallback(_ GeneratorResult) {}
 
 // Generate determines a prime number according to the generator having the specified number of bits
 //
 // In OpenSSL defined generators are 2 and 5. Others are supported but the verification is not supported in an extend as with generators 2 and 5.
-// The bit size should be adjusted to be high enough for the current requirements. Also you should keep
+// The bit size should be adjusted to be high enough for the current requirements. Also, you should keep
 // in mind the higher the bitsize, the longer the generation might take.
 func Generate(bits int, generator Generator, cb GeneratorCallback) (*DH, error) {
 	// Invoke GenerateWithContext with a background context
@@ -154,14 +153,14 @@ func genRand(bits int) (*big.Int, error) {
 
 	buf := make([]byte, bytes)
 	if _, err := rand.Read(buf); err != nil {
-		return nil, errors.Wrap(err, "Unable to read random")
+		return nil, fmt.Errorf("unable to read random: %w", err)
 	}
 
 	if bit == 0 {
 		buf[0] = 1
 		buf[1] |= 0x80
 	} else {
-		buf[0] |= (3 << uint(bit-1))
+		buf[0] |= 3 << uint(bit-1)
 	}
 
 	buf[0] &= byte(^mask)

--- a/generator_test.go
+++ b/generator_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -36,7 +35,7 @@ func execGeneratorIntegration(t *testing.T, bitsize int, generator Generator) {
 
 	buf := new(bytes.Buffer)
 
-	f, err := ioutil.TempFile("", "dhparam.*")
+	f, err := os.CreateTemp("", "dhparam.*")
 	if err != nil {
 		t.Fatalf("Unable to create tempfile: %s", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/Luzifer/go-dhparam
 
-go 1.14
-
-require github.com/pkg/errors v0.9.1
+go 1.19

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/validate.go
+++ b/validate.go
@@ -3,7 +3,7 @@ package dhparam
 import (
 	"math/big"
 
-	"github.com/pkg/errors"
+	"errors"
 )
 
 const dhCheckPNotPrime = 0x01
@@ -23,7 +23,7 @@ var ErrAllParametersOK = errors.New("DH parameters appear to be ok")
 // one error not being equal to ErrAllParametersOK.
 func (d DH) Check() ([]error, bool) {
 	var (
-		result = []error{}
+		result []error
 		ok     = true
 	)
 


### PR DESCRIPTION
update go version, remove errors package (error wrapping is already in standard go) and update deprecated temp file function