### PR TITLE
Add additional errors for Decode

### DIFF
--- a/dh.go
+++ b/dh.go
@@ -6,7 +6,14 @@ import (
 	"encoding/pem"
 	"fmt"
 	"math/big"
+	"errors"
 )
+
+// ErrNoPem is returned if pemData for the Decode function is nil or empty.
+var ErrNoPem = errors.New("empty or nil bytes for PEM data")
+
+// ErrInvalidPem is returned if pemData for the Decode function does not seem to be PEM-encoded data.
+var ErrInvalidPem = errors.New("invalid bytes for PEM data; does not seem to be PEM-encoded")
 
 // DH contains a prime (P) and a generator (G) number representing the DH parameters
 type DH struct {
@@ -16,7 +23,16 @@ type DH struct {
 
 // Decode reads a DH parameters struct from its PEM data
 func Decode(pemData []byte) (*DH, error) {
+
+	if pemData == nil || len(pemData) == nil {
+		return nil, ErrNoPem
+	}
+
 	blk, _ := pem.Decode(pemData)
+	if blk == nil {
+		return nil, ErrInvalidPem
+	}
+
 
 	out := &DH{}
 	if _, err := asn1.Unmarshal(blk.Bytes, out); err != nil {

--- a/dh.go
+++ b/dh.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"encoding/asn1"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"math/big"
-	"errors"
 )
 
 // ErrNoPem is returned if pemData for the Decode function is nil or empty.
@@ -23,8 +23,7 @@ type DH struct {
 
 // Decode reads a DH parameters struct from its PEM data
 func Decode(pemData []byte) (*DH, error) {
-
-	if pemData == nil || len(pemData) == nil {
+	if pemData == nil || len(pemData) == 0 {
 		return nil, ErrNoPem
 	}
 
@@ -32,7 +31,6 @@ func Decode(pemData []byte) (*DH, error) {
 	if blk == nil {
 		return nil, ErrInvalidPem
 	}
-
 
 	out := &DH{}
 	if _, err := asn1.Unmarshal(blk.Bytes, out); err != nil {


### PR DESCRIPTION
The addition of these two new errors prevents a nil pointer dereference when calling `Decode()` with either:

- empty or nil pemData
- non-PEM pemData (e.g. accidental passing of an (encoding/)pem.Block.Bytes instead)

by returning an appropriate error for each case.

I've tried to follow your personal/preferred coding style as close as possible.